### PR TITLE
Added support for ES modules by default

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,9 +1,30 @@
 {
-  "presets": [
-    "stage-0",
-    "es2015"
-  ],
-  "plugins": ["transform-object-assign"],
-  "comments": false,
-  "sourceMaps": true
+  "env": {
+    "es": {
+      "presets": [
+        [
+          "env",
+          {
+            "comments": false,
+            "modules": false,
+            "useBuiltIns": false,
+            "sourceMaps": true
+          }
+        ]
+      ]
+    },
+    "cjs": {
+      "presets": [
+        [
+          "env",
+          {
+            "modules": "commonjs",
+            "comments": false,
+            "sourceMaps": true
+          }
+        ],
+        "stage-1"
+      ]
+    }
+  }
 }

--- a/.babelrc
+++ b/.babelrc
@@ -1,5 +1,17 @@
 {
   "env": {
+    "test": {
+      "presets": [
+        [
+          "env",
+          {
+            "targets": {
+            "node": "current"
+          }
+          }  
+        ]
+      ]
+    },
     "es": {
       "presets": [
         [

--- a/lib/fetchql.es.js
+++ b/lib/fetchql.es.js
@@ -1,9 +1,3 @@
-'use strict';
-
-Object.defineProperty(exports, "__esModule", {
-  value: true
-});
-
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
 function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
@@ -460,4 +454,4 @@ var FetchQL = function (_FetchInterceptor) {
   return FetchQL;
 }(FetchInterceptor);
 
-exports.default = FetchQL;
+export default FetchQL;

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "fetchql.js",
   "module": "fetchql.es.js",
   "scripts": {
-    "test": "istanbul cover _mocha -- ./test/test",
+    "test": "NODE_ENV=test istanbul cover _mocha -- ./test/test",
     "compile": "run-p compile:es compile:cjs",
     "compile:cjs": "NODE_ENV=cjs node_modules/.bin/babel src/index.js --out-file lib/fetchql.js",
     "compile:es": "NODE_ENV=es node_modules/.bin/babel src/index.js --out-file lib/fetchql.es.js",
@@ -41,7 +41,7 @@
     "eslint-plugin-import": "^2.2.0",
     "express": "^4.13.4",
     "graphql": "^0.8.2",
-    "istanbul": "git://github.com/gotwarlost/istanbul.git#harmony",
+    "istanbul": "v1.0.0-alpha.2",
     "mocha": "^3.2.0",
     "node-fetch": "^1.5.2",
     "npm-run-all": "^4.1.2"

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "eslint-plugin-import": "^2.2.0",
     "express": "^4.13.4",
     "graphql": "^0.8.2",
-    "istanbul": "^1.1.0-alpha.1",
+    "istanbul": "git://github.com/gotwarlost/istanbul.git#harmony",
     "mocha": "^3.2.0",
     "node-fetch": "^1.5.2",
     "npm-run-all": "^4.1.2"

--- a/package.json
+++ b/package.json
@@ -2,10 +2,13 @@
   "name": "fetchql",
   "version": "2.1.0",
   "description": "GraphQL query client with Fetch",
-  "main": "index.js",
+  "main": "fetchql.js",
+  "module": "fetchql.es.js",
   "scripts": {
     "test": "istanbul cover _mocha -- ./test/test",
-    "compile": "node_modules/.bin/babel src/index.js --out-file lib/fetchql.js",
+    "compile": "run-p compile:es compile:cjs",
+    "compile:cjs": "NODE_ENV=cjs node_modules/.bin/babel src/index.js --out-file lib/fetchql.js",
+    "compile:es": "NODE_ENV=es node_modules/.bin/babel src/index.js --out-file lib/fetchql.es.js",
     "start": "node_modules/.bin/babel -w src/index.js --out-file lib/fetchql.js",
     "coverage": "cat ./coverage/lcov.info | coveralls",
     "docs": "jsdoc src/index.js ./README.md -d ./docs/"
@@ -26,8 +29,10 @@
     "babel-core": "^6.9.0",
     "babel-plugin-transform-es2015-modules-umd": "^6.18.0",
     "babel-plugin-transform-object-assign": "^6.8.0",
+    "babel-preset-env": "^1.6.1",
     "babel-preset-es2015": "^6.9.0",
     "babel-preset-stage-0": "^6.5.0",
+    "babel-preset-stage-1": "^6.24.1",
     "babel-register": "^6.9.0",
     "chai": "^3.5.0",
     "coveralls": "^2.11.14",
@@ -38,7 +43,8 @@
     "graphql": "^0.8.2",
     "istanbul": "^1.1.0-alpha.1",
     "mocha": "^3.2.0",
-    "node-fetch": "^1.5.2"
+    "node-fetch": "^1.5.2",
+    "npm-run-all": "^4.1.2"
   },
   "dependencies": {}
 }


### PR DESCRIPTION
This PR addresses following things:
1. ES modules are identified by bundlers like webpack/rollup by the `module` field in the package.json file.
2. Modifiled `.babelrc` to transpile less as most of the features are supported by all moder browsers.
3. By default the main file is pointing to `lib/` folder so users just need to `import fetchql from "fetchql"` and based on the bundlers they are using the es module/cjs module will be picked up by default.